### PR TITLE
Upgrade TypeScript and other updates

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,4 @@
   "[typescript]": {
     "editor.formatOnSave": true
   },
-  "prettier.trailingComma": "all",
 }

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # ts-itchio-api
 
 ![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)
-[![styled with prettier](https://img.shields.io/badge/styled_with-prettier-ff69b4.svg)](https://github.com/prettier/prettier)
 
 ts-itchio-api solely contains TypeScript typings for itch.io API objects,
 like games, users, uploads and builds.
@@ -12,7 +11,7 @@ It is not meant to be used directly, but rather shared between several
 npm packages such as:
 
   * [itch](https://github.com/itchio/itch) — the itch.io app
-  * [node-buse](https://github.com/itchio/node-buse) — the buse (butler service) client for node.js
+  * [node-butlerd](https://github.com/itchio/node-butlerd) — the butlerd (butler daemon) client for node.js
 
 ## License
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,36 @@
 {
   "name": "ts-itchio-api",
-  "version": "1.0.1",
-  "lockfileVersion": 1,
+  "version": "1.1.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "ts-itchio-api",
+      "version": "1.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "typescript": "^4.7.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.3.tgz",
+      "integrity": "sha512-WOkT3XYvrpXx4vMMqlD+8R8R37fZkjyLGlxavMc4iB8lrl8L0DeTcHbYgw/v0N/z9wAFsgBhcsF0ruoySS22mA==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    }
+  },
   "dependencies": {
     "typescript": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.6.1.tgz",
-      "integrity": "sha1-7znN6ierrAtQAkLWcmq5DgyEZjE=",
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.3.tgz",
+      "integrity": "sha512-WOkT3XYvrpXx4vMMqlD+8R8R37fZkjyLGlxavMc4iB8lrl8L0DeTcHbYgw/v0N/z9wAFsgBhcsF0ruoySS22mA==",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,6 @@
   },
   "homepage": "https://github.com/itchio/ts-itchio-api#readme",
   "devDependencies": {
-    "typescript": "^2.6.1"
+    "typescript": "^4.7.3"
   }
 }


### PR DESCRIPTION
- Upgrades TypeScript to version 4.7.3
- Removes references to Prettier since it isn't installed
  - Removes VS Code trailing comma setting
  - Removes README badge
- Updates node-buse reference in README
- Upgrades package-lock.json to version 2